### PR TITLE
Sign up: adiciona username no cadastro

### DIFF
--- a/app/assets/javascripts/app_sign_up.coffee
+++ b/app/assets/javascripts/app_sign_up.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/app_sign_up.scss
+++ b/app/assets/stylesheets/app_sign_up.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the app_sign_up controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/app_sign_up_controller.rb
+++ b/app/controllers/app_sign_up_controller.rb
@@ -1,0 +1,30 @@
+class AppSignUpController < Devise::RegistrationsController
+  def create
+    print "Create\n\n"
+    render json: { msg: "OI" }
+    # build_resource(sign_up_params)
+
+    # resource.save
+    # yield resource if block_given?
+    # if resource.persisted?
+    #   if resource.active_for_authentication?
+    #     set_flash_message! :notice, :signed_up
+    #     sign_up(resource_name, resource)
+    #     respond_with resource, location: after_sign_up_path_for(resource)
+    #   else
+    #     set_flash_message! :notice, :"signed_up_but_#{resource.inactive_message}"
+    #     expire_data_after_sign_in!
+    #     respond_with resource, location: after_inactive_sign_up_path_for(resource)
+    #   end
+    # else
+    #   clean_up_passwords resource
+    #   set_minimum_password_length
+    #   respond_with resource
+    # end
+  end
+
+  # def registration_params
+  #   params.require(:user).permit(:email, :title_id, :first_name, :last_name, 
+  #     :province_id, :password, :password_confirmation)
+  # end
+end

--- a/app/controllers/app_sign_up_controller.rb
+++ b/app/controllers/app_sign_up_controller.rb
@@ -1,30 +1,29 @@
 class AppSignUpController < Devise::RegistrationsController
   def create
-    print "Create\n\n"
-    render json: { msg: "OI" }
-    # build_resource(sign_up_params)
+    build_resource(sign_up_params)
 
-    # resource.save
-    # yield resource if block_given?
-    # if resource.persisted?
-    #   if resource.active_for_authentication?
-    #     set_flash_message! :notice, :signed_up
-    #     sign_up(resource_name, resource)
-    #     respond_with resource, location: after_sign_up_path_for(resource)
-    #   else
-    #     set_flash_message! :notice, :"signed_up_but_#{resource.inactive_message}"
-    #     expire_data_after_sign_in!
-    #     respond_with resource, location: after_inactive_sign_up_path_for(resource)
-    #   end
-    # else
-    #   clean_up_passwords resource
-    #   set_minimum_password_length
-    #   respond_with resource
-    # end
+    print resource.as_json
+
+    resource.save
+    yield resource if block_given?
+    if resource.persisted?
+
+      # Check if model is active
+      if resource.active_for_authentication?
+        sign_up(resource_name, resource)
+        render json: { status: "OK" }
+      else
+        expire_data_after_sign_in!
+        render json: { status: "ERROR" }
+      end
+    else
+      clean_up_passwords resource
+      set_minimum_password_length
+      render json: { status: "ERROR_AUTH", errors: resource.errors.as_json }
+    end
   end
 
-  # def registration_params
-  #   params.require(:user).permit(:email, :title_id, :first_name, :last_name, 
-  #     :province_id, :password, :password_confirmation)
-  # end
+  def registration_params
+    params.require(:user).permit(:email,  :password, :password_confirmation, :username)
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
+  end
 end

--- a/app/helpers/app_sign_up_helper.rb
+++ b/app/helpers/app_sign_up_helper.rb
@@ -1,0 +1,2 @@
+module AppSignUpHelper
+end

--- a/app/javascript/components/auth/SignIn.jsx
+++ b/app/javascript/components/auth/SignIn.jsx
@@ -1,22 +1,29 @@
 import React from 'react';
 import axios from 'axios';
-import { Grid, Paper, Typography, TextField, Button } from '@material-ui/core';
+import {
+  Grid,
+  Paper,
+  Typography,
+  TextField,
+  Button,
+  Fade
+} from '@material-ui/core';
 import { routes } from '../../config';
-import { Message } from '../'
+import { Message } from '../';
 
 class SignIn extends React.Component {
   state = {
     email: '',
     password: '',
-    open: false, 
+    open: false,
     message: ''
   };
 
   handleChange = e => this.setState({ [e.target.name]: e.target.value });
 
   toggleMenu = () => {
-      this.setState({open: false});
-  }
+    this.setState({ open: false });
+  };
 
   submit = () => {
     axios({
@@ -37,81 +44,84 @@ class SignIn extends React.Component {
       }
     })
       .then(res => {
-        const isUserSignedIn = res.data.includes('user-signed-in="true"')
-        if(isUserSignedIn)
-          window.location.href = routes.home;
-        else
-          this.setState({ open: true });  
-          this.setState({ message: 'E-mail ou senha errado.' });    
+        const isUserSignedIn = res.data.includes('user-signed-in="true"');
+        if (isUserSignedIn) window.location.href = routes.home;
+        else this.setState({ open: true });
+        this.setState({ message: 'E-mail ou senha errado.' });
       })
       .catch(err => console.log(err));
   };
 
-
   render() {
     return (
       <div>
-      <Message open = {this.state.open} mensagem = {this.state.message} toggleMenu = {this.toggleMenu}/>
-      <Grid
-        container
-        justify="center"
-        spacing={32}
-        style={{
-          position: 'absolute',
-          top: '25%'
-        }}
-      >
-        <Grid item md={6} xs={10}>
-          <Paper elevation={4}>
-            <form style={{ padding: 32 }}>
-              <Grid container direction="column" spacing={24}>
-                <Grid item>
-                  <Typography variant="h6" align="center">
-                    Sign in to MAC0218
-                  </Typography>
-                </Grid>
-
-                <Grid item>
-                  <Grid container direction="column" spacing={32}>
+        <Message
+          open={this.state.open}
+          mensagem={this.state.message}
+          toggleMenu={this.toggleMenu}
+        />
+        <Grid
+          container
+          justify="center"
+          spacing={32}
+          style={{
+            position: 'absolute',
+            top: '25%'
+          }}
+        >
+          <Grid item md={6} xs={10}>
+            <Fade in={true}>
+              <Paper elevation={4}>
+                <form style={{ padding: 32 }}>
+                  <Grid container direction="column" spacing={24}>
                     <Grid item>
-                      <TextField
-                        label="Email"
-                        variant="outlined"
-                        fullWidth
-                        name="email"
-                        onChange={this.handleChange}
-                        value={this.state.email}
-                      />
+                      <Typography variant="h6" align="center">
+                        Sign in to MAC0218
+                      </Typography>
                     </Grid>
 
                     <Grid item>
-                      <TextField
-                        label="Password"
-                        type="password"
-                        variant="outlined"
-                        fullWidth
-                        name="password"
-                        onChange={this.handleChange}
-                        value={this.state.password}
-                      />
-                    </Grid>
+                      <Grid container direction="column" spacing={32}>
+                        <Grid item>
+                          <TextField
+                            label="Email"
+                            variant="outlined"
+                            fullWidth
+                            name="email"
+                            onChange={this.handleChange}
+                            value={this.state.email}
+                          />
+                        </Grid>
 
-                    <Grid item>
-                      <Button
-                        variant="contained"
-                        fullWidth
-                        onClick={this.submit}
-                      >
-                        Submit
-                  </Button>
+                        <Grid item>
+                          <TextField
+                            label="Password"
+                            type="password"
+                            variant="outlined"
+                            fullWidth
+                            name="password"
+                            onChange={this.handleChange}
+                            value={this.state.password}
+                          />
+                        </Grid>
+
+                        <Grid item>
+                          <Button
+                            variant="contained"
+                            fullWidth
+                            onClick={this.submit}
+                          >
+                            Submit
+                          </Button>
+                        </Grid>
+                      </Grid>
                     </Grid>
                   </Grid>
-                </Grid>
-              </Grid>
-            </form>
-          </Paper>
+                </form>
+              </Paper>
+            </Fade>
+          </Grid>
         </Grid>
-      </Grid>
       </div>
     );
   }

--- a/app/javascript/components/auth/SignUp.jsx
+++ b/app/javascript/components/auth/SignUp.jsx
@@ -1,7 +1,16 @@
 import React from 'react';
 import axios from 'axios';
-import { Grid, Paper, Typography, TextField, Button } from '@material-ui/core';
+import {
+  Grid,
+  Paper,
+  Typography,
+  TextField,
+  Button,
+  Fade
+} from '@material-ui/core';
+
 import { routes } from '../../config';
+import { Services } from '../../services';
 
 class SignUp extends React.Component {
   state = {
@@ -11,30 +20,14 @@ class SignUp extends React.Component {
   };
 
   submit = () => {
-    axios({
-      method: 'POST',
-      url: '/users/',
-      headers: {
-        'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content
-      },
-      data: {
-        user: {
-          email: this.state.email,
-          password: this.state.password,
-          password_confirmation: this.state.password_confirmation
-        },
-        authenticity_token: this.props.authToken,
-        commit: 'Sign up',
-        utf8: '✓'
-      }
+    const { username, email, password, password_confirmation } = this.state;
+    Services.Api.Auth.sign_up({
+      username,
+      email,
+      password,
+      password_confirmation
     })
-      .then(res => {
-        const isUserSignedIn = res.data.includes('user-signed-in="true"')
-        if(isUserSignedIn)
-          window.location.href = routes.home;
-        else
-          window.location.reload();
-      })
+      .then(res => console.log(res))
       .catch(err => console.log(err));
   };
 
@@ -52,58 +45,60 @@ class SignUp extends React.Component {
         }}
       >
         <Grid item md={6} xs={10}>
-          <Paper elevation={4}>
-            <form style={{ padding: 32 }}>
-              <Grid container direction="column" spacing={24}>
-                <Grid item>
-                  <Typography variant="h6" align="center">
-                    Create account
-                  </Typography>
-                </Grid>
+          <Fade in={true}>
+            <Paper elevation={4}>
+              <form style={{ padding: 32 }}>
+                <Grid container direction="column" spacing={24}>
+                  <Grid item>
+                    <Typography variant="h6" align="center">
+                      Create account
+                    </Typography>
+                  </Grid>
 
-                <Grid item>
-                  <TextField
-                    label="Email"
-                    name="email"
-                    variant="outlined"
-                    fullWidth
-                    onChange={this.handleChange}
-                    value={this.state.email}
-                  />
-                </Grid>
+                  <Grid item>
+                    <TextField
+                      label="Email"
+                      name="email"
+                      variant="outlined"
+                      fullWidth
+                      onChange={this.handleChange}
+                      value={this.state.email}
+                    />
+                  </Grid>
 
-                <Grid item>
-                  <TextField
-                    label="Password"
-                    name="password"
-                    variant="outlined"
-                    fullWidth
-                    type="password"
-                    onChange={this.handleChange}
-                    value={this.state.password}
-                  />
-                </Grid>
+                  <Grid item>
+                    <TextField
+                      label="Password"
+                      name="password"
+                      variant="outlined"
+                      fullWidth
+                      type="password"
+                      onChange={this.handleChange}
+                      value={this.state.password}
+                    />
+                  </Grid>
 
-                <Grid item>
-                  <TextField
-                    label="Password Confirmation"
-                    name="password_confirmation"
-                    variant="outlined"
-                    fullWidth
-                    type="password"
-                    onChange={this.handleChange}
-                    value={this.state.password_confirmation}
-                  />
-                </Grid>
+                  <Grid item>
+                    <TextField
+                      label="Password Confirmation"
+                      name="password_confirmation"
+                      variant="outlined"
+                      fullWidth
+                      type="password"
+                      onChange={this.handleChange}
+                      value={this.state.password_confirmation}
+                    />
+                  </Grid>
 
-                <Grid item>
-                  <Button variant="contained" fullWidth onClick={this.submit}>
-                    Submit
-                  </Button>
+                  <Grid item>
+                    <Button variant="contained" fullWidth onClick={this.submit}>
+                      Submit
+                    </Button>
+                  </Grid>
                 </Grid>
-              </Grid>
-            </form>
-          </Paper>
+              </form>
+            </Paper>
+          </Fade>
         </Grid>
       </Grid>
     );

--- a/app/javascript/components/auth/SignUp.jsx
+++ b/app/javascript/components/auth/SignUp.jsx
@@ -8,18 +8,22 @@ import {
   Button,
   Fade
 } from '@material-ui/core';
+import { withRouter } from 'react-router';
 
 import { routes } from '../../config';
 import { Services } from '../../services';
 
 class SignUp extends React.Component {
   state = {
+    username: '',
     email: '',
     password: '',
-    password_confirmation: ''
+    password_confirmation: '',
+    errors: {}
   };
 
   submit = () => {
+    const { history } = this.props;
     const { username, email, password, password_confirmation } = this.state;
     Services.Api.Auth.sign_up({
       username,
@@ -27,13 +31,25 @@ class SignUp extends React.Component {
       password,
       password_confirmation
     })
-      .then(res => console.log(res))
+      .then(res => {
+        const { errors, status } = res.data;
+
+        if (status === 'OK') {
+          window.location = routes.home;
+        } else if (status === 'ERROR_AUTH') {
+          this.setState({ errors });
+        } else {
+          // TODO handle error
+        }
+      })
       .catch(err => console.log(err));
   };
 
   handleChange = e => this.setState({ [e.target.name]: e.target.value });
 
   render() {
+    const { errors } = this.state;
+
     return (
       <Grid
         container
@@ -57,12 +73,27 @@ class SignUp extends React.Component {
 
                   <Grid item>
                     <TextField
+                      label="Username"
+                      name="username"
+                      variant="outlined"
+                      fullWidth
+                      onChange={this.handleChange}
+                      value={this.state.username}
+                      error={!!errors.username}
+                      helperText={errors.username}
+                    />
+                  </Grid>
+
+                  <Grid item>
+                    <TextField
                       label="Email"
                       name="email"
                       variant="outlined"
                       fullWidth
                       onChange={this.handleChange}
                       value={this.state.email}
+                      error={!!errors.email}
+                      helperText={errors.email}
                     />
                   </Grid>
 
@@ -75,6 +106,8 @@ class SignUp extends React.Component {
                       type="password"
                       onChange={this.handleChange}
                       value={this.state.password}
+                      error={!!errors.password}
+                      helperText={errors.password}
                     />
                   </Grid>
 
@@ -87,6 +120,8 @@ class SignUp extends React.Component {
                       type="password"
                       onChange={this.handleChange}
                       value={this.state.password_confirmation}
+                      error={!!errors.password_confirmation}
+                      helperText={errors.password_confirmation}
                     />
                   </Grid>
 
@@ -105,4 +140,4 @@ class SignUp extends React.Component {
   }
 }
 
-export default SignUp;
+export default withRouter(SignUp);

--- a/app/javascript/config/routes.js
+++ b/app/javascript/config/routes.js
@@ -35,6 +35,7 @@ export const routes = {
       '/api/problems/update_multiple_choice_favorites',
     get_user_favorite_problems: '/api/problems/get_multiple_choice_favorites',
     update_multiple_choice: `/api/problems/update_multiple_choice`,
-    delete_multiple_choice: `/api/problems/delete_multiple_choice`
+    delete_multiple_choice: `/api/problems/delete_multiple_choice`,
+    sign_up: '/api/auth/sign_up'
   }
 };

--- a/app/javascript/services/api/auth.js
+++ b/app/javascript/services/api/auth.js
@@ -1,0 +1,29 @@
+import axios from 'axios';
+import { routes } from '../../config';
+
+const sign_up = ({ username, email, password, password_confirmation }) =>
+  new Promise((resolve, reject) => {
+    console.log(email);
+    axios({
+      method: 'POST',
+      url: routes.api.sign_up,
+      headers: {
+        'X-CSRF-Token': document.querySelector('meta[name=csrf-token]').content
+      },
+      data: {
+        user: {
+          email: email,
+          password: password,
+          password_confirmation: password_confirmation
+        },
+        commit: 'Sign up',
+        utf8: '✓'
+      }
+    })
+      .then(res => resolve(res))
+      .catch(err => reject(err));
+  });
+
+export const Auth = {
+  sign_up
+};

--- a/app/javascript/services/api/auth.js
+++ b/app/javascript/services/api/auth.js
@@ -3,7 +3,6 @@ import { routes } from '../../config';
 
 const sign_up = ({ username, email, password, password_confirmation }) =>
   new Promise((resolve, reject) => {
-    console.log(email);
     axios({
       method: 'POST',
       url: routes.api.sign_up,
@@ -12,9 +11,10 @@ const sign_up = ({ username, email, password, password_confirmation }) =>
       },
       data: {
         user: {
-          email: email,
-          password: password,
-          password_confirmation: password_confirmation
+          username,
+          email,
+          password,
+          password_confirmation
         },
         commit: 'Sign up',
         utf8: '✓'

--- a/app/javascript/services/api/index.js
+++ b/app/javascript/services/api/index.js
@@ -1,3 +1,4 @@
 import { MultipleChoice } from './multipleChoice';
+import { Auth } from './auth';
 
-export const Api = { MultipleChoice };
+export const Api = { MultipleChoice, Auth };

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,9 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  validates_presence_of :username
+  validates_uniqueness_of :username
+
   has_many :multiple_choice_problems, dependent: :destroy
   has_many :multiple_choice_favorites, dependent: :destroy
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,11 @@ Rails.application.routes.draw do
   get 'api/problems/get_multiple_choice_favorites' => 'problems#get_multiple_choice_favorites'
 
   post 'api/problems/update_multiple_choice_favorites' => 'problems#update_multiple_choice_favorites'
+
+  # Authentication
+  devise_scope :user do
+    post 'api/auth/sign_up' => 'app_sign_up#create'
+  end
   
   match '*path', to: 'home#index', via: :all
 end

--- a/db/migrate/20190523144034_add_username_to_users.rb
+++ b/db/migrate/20190523144034_add_username_to_users.rb
@@ -1,0 +1,5 @@
+class AddUsernameToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :username, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_12_031504) do
+ActiveRecord::Schema.define(version: 2019_05_23_144034) do
 
   create_table "alternatives", force: :cascade do |t|
     t.string "text"
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 2019_05_12_031504) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "username"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/test/controllers/app_sign_up_controller_test.rb
+++ b/test/controllers/app_sign_up_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AppSignUpControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
- A tela de cadastro sofreu alterações para que o usuário pudesse escolher um nome de usuário.
- Foi criado uma rota para cadastro e uma chamada da API que realiza o cadastro.
- No servidor, foi criado um controlador que herda de um controlador do **devise**. Esse controlador dá **override** no método para cadastro de usuário.
- No modelo de usuário, foi adicionado o campo username.